### PR TITLE
Add local mongo and redis with docker

### DIFF
--- a/backend-controller.js
+++ b/backend-controller.js
@@ -21,8 +21,7 @@ var paretoContractAddress = process.env.CRED_PARETOCONTRACT || constants.pareto_
 const modelsPath = path.resolve(__dirname, 'models');
 fs.readdirSync(modelsPath).forEach(file => {
   require(modelsPath + '/' + file);
-})
-
+});
 
 const redis = require("redis");
 redisClient = redis.createClient(


### PR DESCRIPTION
Adds a validation to only attempt to load  the backend-private-constants.json if it exists, this was throwing and exception into Heroku becuase that file is not part of the repo.

2018-04-30T15:35:39.768997+00:00 app[web.1]: Error: Cannot find module './backend-private-constants.json'
2018-04-30T15:35:39.768999+00:00 app[web.1]:     at Function.Module._resolveFilename (module.js:547:15)
2018-04-30T15:35:39.769001+00:00 app[web.1]:     at Function.Module._load (module.js:474:25)
2018-04-30T15:35:39.769003+00:00 app[web.1]:     at Module.require (module.js:596:17)
2018-04-30T15:35:39.769004+00:00 app[web.1]:     at require (internal/module.js:11:18)
2018-04-30T15:35:39.769006+00:00 app[web.1]:     at Object.<anonymous> (/app/backend-controller.js:18:29)