### PR TITLE
add $ to variables block and tokens when fecth mongo

### DIFF
--- a/backend-controller.js
+++ b/backend-controller.js
@@ -797,8 +797,8 @@ controller.getScoreAndSaveRedis = function(callback){
         "$push": {
           "address" : "$address",
           "score" : "$score",
-            "block" : "block",
-            "tokens" : "tokens"
+            "block" : "$block",
+            "tokens" : "$tokens"
         }
       }}).unwind({
     "path": "$addresses",


### PR DESCRIPTION
Fixes the issue related to returning the tokens like this:
`{"address":"0x1cd35769e5e5e03493dc532bddd0d94f5a8723b2","score":"16795.101712757267","block":"block","tokens":"tokens","rank":"4130"}`